### PR TITLE
Use updated fibers

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/telerik/ios-sim-portable",
   "dependencies": {
     "colors": "0.6.2",
-    "fibers": "https://github.com/icenium/node-fibers/tarball/master",
+    "fibers": "https://github.com/icenium/node-fibers/tarball/vladimirov/fibers_1_0_5_fixes",
     "NodObjC": "https://github.com/telerik/NodObjC/tarball/master",
     "underscore": "1.6.0",
     "yargs": "1.2.2"


### PR DESCRIPTION
Change package.json to use vladimirov/fibers_1_0_5_fixes branch where node-fibers are built with all the latest fixes. This is a temporary change that has to be removed after merging vladimirov/fibers_1_0_5_fixes into master of node-fibers repo. The temp change is required for testing purposes.