### PR TITLE
Add supported engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-sim-portable",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "main": "./lib/ios-sim.js",
   "scripts": {
@@ -36,5 +36,8 @@
       "grunt-contrib-clean": "0.5.0",
       "grunt": "0.4.2",
       "grunt-ts": "1.11.2"
+  },
+  "engines": {
+    "node": ">=0.10.26 <0.10.34 || >=0.10.35 <0.11.0"
   }
 }


### PR DESCRIPTION
Add node as engine and set supported version to be at least 0.10.26 and at most 0.10.x (excluding 0.10.34).