### PR TITLE
Pass the 'args' options to the simulator

### DIFF
--- a/lib/iphone-simulator.js
+++ b/lib/iphone-simulator.js
@@ -143,6 +143,15 @@ var iPhoneSimulator = (function () {
             }
         }
 
+        if (options.args) {
+            var args = options.args.trim().split(/\s+/);
+            var nsArgs = $.NSMutableArray("array");
+            args.forEach(function (x) {
+                return nsArgs("addObject", $(x));
+            });
+            config("setSimulatedApplicationLaunchArgs", nsArgs);
+        }
+
         config("setLocalizedClientName", $("ios-sim-portable"));
 
         var sessionError = new Buffer("");

--- a/lib/iphone-simulator.ts
+++ b/lib/iphone-simulator.ts
@@ -146,6 +146,13 @@ export class iPhoneSimulator implements IiPhoneSimulator {
 			}
 		}
 
+		if (options.args) {
+			var args = options.args.trim().split(/\s+/);
+			var nsArgs = $.NSMutableArray("array");
+			args.forEach((x: string) => nsArgs("addObject", $(x)));
+			config("setSimulatedApplicationLaunchArgs", nsArgs);
+		}
+
 		config("setLocalizedClientName", $("ios-sim-portable"));
 
 		var sessionError: any = new Buffer("");


### PR DESCRIPTION
We need this in NativeScript for iOS to start the app waiting for a debugger.