### PR TITLE
Add support for node 4.1.x+

### DIFF
--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -17,7 +17,7 @@ interface ICommandExecutor {
 }
 
 interface IDevice {
-	device: any; // NodObjC wrapper to device
+	device: any; // nodobjc wrapper to device
 	deviceIdentifier: string;
 	fullDeviceIdentifier: string;
 	runtimeVersion: string;

--- a/lib/definitions/NodObjC.d.ts
+++ b/lib/definitions/NodObjC.d.ts
@@ -1,4 +1,4 @@
-declare module "NodObjC" {
+declare module "nodobjc" {
 	export function importFramework(frameworkName: string): void;
 	export var classDefinition: IClass;
 

--- a/lib/iphone-simulator-xcode-5.js
+++ b/lib/iphone-simulator-xcode-5.js
@@ -1,7 +1,7 @@
 ///<reference path="./.d.ts"/>
 "use strict";
 var options = require("./options");
-var $ = require("NodObjC");
+var $ = require("nodobjc");
 var XCode5Simulator = (function () {
     function XCode5Simulator() {
     }

--- a/lib/iphone-simulator-xcode-5.ts
+++ b/lib/iphone-simulator-xcode-5.ts
@@ -6,7 +6,7 @@ import options = require("./options");
 import utils = require("./utils");
 import util = require("util");
 
-var $ = require("NodObjC");
+var $ = require("nodobjc");
 
 export class XCode5Simulator implements ISimulator {
 

--- a/lib/iphone-simulator-xcode-6.js
+++ b/lib/iphone-simulator-xcode-6.js
@@ -4,7 +4,7 @@ var errors = require("./errors");
 var options = require("./options");
 var util = require("util");
 var os = require("os");
-var $ = require("NodObjC");
+var $ = require("nodobjc");
 var XCode6Simulator = (function () {
     function XCode6Simulator() {
         this.availableDevices = Object.create(null);

--- a/lib/iphone-simulator-xcode-6.ts
+++ b/lib/iphone-simulator-xcode-6.ts
@@ -5,7 +5,7 @@ import options = require("./options");
 import utils = require("./utils");
 import util = require("util");
 import os = require("os");
-var $ = require("NodObjC");
+var $ = require("nodobjc");
 
 export class XCode6Simulator implements ISimulator {
 

--- a/lib/iphone-simulator.js
+++ b/lib/iphone-simulator.js
@@ -11,7 +11,7 @@ var options = require("./options");
 var utils = require("./utils");
 var xcode6SimulatorLib = require("./iphone-simulator-xcode-6");
 var xcode5SimulatorLib = require("./iphone-simulator-xcode-5");
-var $ = require("NodObjC");
+var $ = require("nodobjc");
 var iPhoneSimulator = (function () {
     function iPhoneSimulator() {
     }
@@ -101,7 +101,7 @@ var iPhoneSimulator = (function () {
         });
         sessionDelegate.addMethod("session:didStart:withError:", "v@:@c@", function (self, sel, session, started, error) {
             iPhoneSimulator.logSessionInfo(error, "Session started without errors.", "Session started with error ");
-            console.log(appPath + " " + session("simulatedApplicationPID"));
+            console.log(appPath + ": " + session("simulatedApplicationPID"));
             if (options.exit) {
                 process.exit(0);
             }

--- a/lib/iphone-simulator.ts
+++ b/lib/iphone-simulator.ts
@@ -14,7 +14,7 @@ import utils = require("./utils");
 import xcode6SimulatorLib = require("./iphone-simulator-xcode-6");
 import xcode5SimulatorLib = require("./iphone-simulator-xcode-5");
 
-var $ = require("NodObjC");
+var $ = require("nodobjc");
 
 export class iPhoneSimulator implements IiPhoneSimulator {
 

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
   },
   "homepage": "https://github.com/telerik/ios-sim-portable",
   "dependencies": {
-    "NodObjC": "https://github.com/telerik/NodObjC/tarball/v1.0.0.0",
     "colors": "0.6.2",
     "fibers": "https://github.com/icenium/node-fibers/tarball/v1.0.6.0",
     "lodash": "3.2.0",
+    "nodobjc": "https://github.com/telerik/NodObjC/tarball/v2.0.0.0",
     "yargs": "1.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Add support for Node 4.1.x+ by updating NodeObjC module.
It has been renamed to nodobjc, so replace the using in our code.