### PR TITLE
Add support for node 5.1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-sim-portable",
-  "version": "1.0.13-epsilon",
+  "version": "1.0.13",
   "description": "",
   "main": "./lib/ios-sim.js",
   "scripts": {
@@ -28,9 +28,9 @@
   "dependencies": {
     "bplist-parser": "0.1.0",
     "colors": "0.6.2",
-    "fibers": "https://github.com/icenium/node-fibers/tarball/v1.0.6.0",
+    "fibers": "https://github.com/icenium/node-fibers/tarball/v1.0.6.3",
     "lodash": "3.2.0",
-    "nodobjc": "https://github.com/telerik/NodObjC/tarball/v2.0.0.0",
+    "nodobjc": "https://github.com/telerik/NodObjC/tarball/v2.0.0.1",
     "osenv": "0.1.3",
     "yargs": "3.15.0"
   },
@@ -41,6 +41,6 @@
     "typescript": "1.6.2"
   },
   "engines": {
-    "node": ">=0.10.40 <0.11.0 || >=0.12.7 <0.13.0 || >=4.2.1 <5.0.0"
+    "node": ">=0.10.40 <0.11.0 || >=0.12.7 <0.13.0 || >=4.2.1 <5.0.0 || >=5.1.0 <6.0.0"
   }
 }


### PR DESCRIPTION
Add support for node 5.1.x by updating references. Set node versions between 5.1.0 and 6.0.0 as verified.