### PR TITLE
Fixes #50 - xcode7 sim launch error.

### DIFF
--- a/lib/iphone-simulator-xcode-7.ts
+++ b/lib/iphone-simulator-xcode-7.ts
@@ -10,7 +10,7 @@ import { Simctl } from "./simctl";
 import util = require("util");
 import utils = require("./utils");
 import xcode = require("./xcode");
-var $ = require("NodObjC");
+var $ = require("nodobjc");
 var osenv = require("osenv");
 
 export class XCode7Simulator implements ISimulator {


### PR DESCRIPTION
I believe this fixes #50. The module name has changed to be lower case (NodObjC --> nodobjc). This has been changed in other source files, but looks like this file may have been overlooked, which prevented the xcode7 simulator from launching.