### PR TITLE
Add filtering for simulator logs based on the PID of the started process.

### DIFF
--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -55,7 +55,7 @@ interface ISimulator {
 	uninstallApplication(deviceId: string, appIdentifier: string): IFuture<void>;
 	startApplication(deviceId: string, appIdentifier: string): IFuture<string>;
 	stopApplication(deviceId: string, appIdentifier: string): IFuture<string>;
-	printDeviceLog(deviceId: string): void;
+	printDeviceLog(deviceId: string, launchResult?: string): void;
 	startSimulator(): IFuture<void>;
 }
 

--- a/lib/iphone-simulator-common.ts
+++ b/lib/iphone-simulator-common.ts
@@ -37,18 +37,36 @@ export function getInstalledApplications(deviceId: string): IFuture<IApplication
 	}).future<IApplication[]>()();
 }
 
-export function printDeviceLog(deviceId: string): void {
+export function printDeviceLog(deviceId: string, launchResult?: string): void {
 	let logFilePath = path.join(osenv.home(), "Library", "Logs", "CoreSimulator", deviceId, "system.log");
-
+	let pid: string;
+	if(launchResult) {
+		pid = launchResult.split(":")[1].trim();
+	}
 	let childProcess = require("child_process").spawn("tail", ['-f', '-n', '1', logFilePath]);
 	if (childProcess.stdout) {
 		childProcess.stdout.on("data", (data: NodeBuffer) => {
-			process.stdout.write(data.toString());
+			let dataAsString = data.toString();
+			if(pid) {
+				if (dataAsString.indexOf(`[${pid}]`) > -1) {
+					process.stdout.write(dataAsString);
+				}
+			} else {
+				process.stdout.write(dataAsString);
+			}
 		});
 	}
 
 	if (childProcess.stderr) {
 		childProcess.stderr.on("data", (data: string) => {
+			let dataAsString = data.toString();
+			if(pid) {
+				if (dataAsString.indexOf(`[${pid}]`) > -1) {
+					process.stdout.write(dataAsString);
+				}
+			} else {
+				process.stdout.write(dataAsString);
+			}
 			process.stdout.write(data.toString());
 		});
 	}

--- a/lib/iphone-simulator-xcode-6.ts
+++ b/lib/iphone-simulator-xcode-6.ts
@@ -80,8 +80,8 @@ export class XCode6Simulator extends iPhoneSimulatorBaseLib.IPhoneInteropSimulat
 		}
 	}
 
-	public printDeviceLog(deviceId: string): void {
-		common.printDeviceLog(deviceId);
+	public printDeviceLog(deviceId: string, launchResult?: string): void {
+		common.printDeviceLog(deviceId, launchResult);
 	}
 
 	public startSimulator(): IFuture<void> {

--- a/lib/iphone-simulator-xcode-7.ts
+++ b/lib/iphone-simulator-xcode-7.ts
@@ -54,27 +54,7 @@ export class XCode7Simulator implements ISimulator {
 			let launchResult = this.simctl.launch(device.id, applicationIdentifier).wait();
 
 			if (options.logging) {
-				let pid = launchResult.split(":")[1].trim();
-				let logFilePath = path.join(osenv.home(), "Library", "Logs", "CoreSimulator", device.id, "system.log");
-
-				let childProcess = require("child_process").spawn("tail", ['-f', '-n', '1', logFilePath]);
-				if(childProcess.stdout) {
-					childProcess.stdout.on("data", (data: NodeBuffer) => {
-						let dataAsString = data.toString();
-						if (dataAsString.indexOf(`[${pid}]`) > -1) {
-							process.stdout.write(dataAsString);
-						}
-					});
-				}
-
-				if(childProcess.stderr) {
-					childProcess.stderr.on("data", (data: string) => {
-						let dataAsString = data.toString();
-						if (dataAsString.indexOf(`[${pid}]`) > -1) {
-							process.stdout.write(dataAsString);
-						}
-					});
-				}
+				this.printDeviceLog(device.id, launchResult);
 			}
 		}).future<void>()();
 	}
@@ -117,8 +97,8 @@ export class XCode7Simulator implements ISimulator {
 		}
 	}
 
-	public printDeviceLog(deviceId: string): void {
-		common.printDeviceLog(deviceId);
+	public printDeviceLog(deviceId: string, launchResult?: string): void {
+		common.printDeviceLog(deviceId, launchResult);
 	}
 
 	private getDeviceToRun(): IFuture<IDevice> {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-sim-portable",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "",
   "main": "./lib/ios-sim.js",
   "scripts": {


### PR DESCRIPTION
Add filtering for simulator logs based on the PID of the started process.
In order to use the filtering, just pass the output of startApplication method as a second parameter of printDeviceLog method.