### PR TITLE
Respect optional deviceName parameter passed

### DIFF
--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -60,7 +60,7 @@ interface ISimulator extends INameGetter {
 }
 
 interface INameGetter {
-	getSimulatorName(deviceId: string): string;
+	getSimulatorName(deviceName?: string): string;
 }
 
 interface IApplication {

--- a/lib/iphone-simulator-name-getter.ts
+++ b/lib/iphone-simulator-name-getter.ts
@@ -7,9 +7,9 @@ export abstract class IPhoneSimulatorNameGetter implements INameGetter {
 
 	public defaultDeviceIdentifier: string;
 
-	public getSimulatorName(): string {
+	public getSimulatorName(deviceName?: string): string {
 		if (!this._simulatorName) {
-			this._simulatorName = options.device || this.defaultDeviceIdentifier;
+			this._simulatorName = options.device || deviceName || this.defaultDeviceIdentifier;
 		}
 
 		return this._simulatorName;


### PR DESCRIPTION
However, use the name passed as a command-line option with priority.
Note that ios-sim-portable should be refactored to take the currently running simulator into account on its own, instead of having to pass it as a param from the outside.
Ping @rosen-vladimirov 