### PR TITLE
Fix filtering of iOS Simulator logs per pid of new process

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-sim-portable",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "",
   "main": "./lib/ios-sim.js",
   "scripts": {


### PR DESCRIPTION
When application is restarted, the PID of the process is changed. So when showing device logs, we should change the pid when the printDeviceLog is called.
Spawn the process (`tail -f ...`) only one time, but change the PID whenever the method is called.