### PR TITLE
Fix parsing of simulator plist files

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lodash": "3.2.0",
     "nodobjc": "https://github.com/telerik/NodObjC/tarball/v2.0.0.1",
     "osenv": "0.1.3",
+    "plist": "1.1.0",
     "yargs": "3.15.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-sim-portable",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "",
   "main": "./lib/ios-sim.js",
   "scripts": {


### PR DESCRIPTION
Some watchkit apps have xml plist file and when we try to read them as binary plists, the bplist module fails.
Catch this error and try to parse them with plist module.