### PR TITLE
Set version to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-sim-portable",
-  "version": "1.0.24",
+  "version": "1.1.0",
   "description": "",
   "main": "./lib/ios-sim.js",
   "scripts": {


### PR DESCRIPTION
Currently our CLIs install latest 1.0.x version directly. In the new version (1.0.24) the fibers module is changed which causes errors `[Object object] is not a future`. This is due to the fact that fibers module is installed in both CLI and ios-sim-portable.
