### PR TITLE
Fix [object Object] is not a future

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "ios-sim-portable",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "main": "./lib/ios-sim.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "prepublish": "node prepublish.js"
+    "prepublish": "node prepublish.js",
+    "postinstall": "node postinstall.js"
   },
   "bin": {
     "ios-sim-portable": "./bin/ios-sim-portable.js",
@@ -33,7 +34,8 @@
     "nodobjc": "https://github.com/telerik/NodObjC/tarball/v2.0.0.2",
     "osenv": "0.1.3",
     "plist": "1.1.0",
-    "yargs": "3.15.0"
+    "shelljs": "0.7.0",
+    "yargs": "4.7.1"
   },
   "devDependencies": {
     "grunt-contrib-clean": "0.6.0",

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,22 @@
+"use strict";
+
+var shelljs = require("shelljs"),
+	fs = require("fs"),
+	path = require("path"),
+	fibersDirName = "fibers",
+	nodeModulesDirName = "node_modules";
+
+try {
+	// In case there are fibers in upper level's node_modules dir, we should remove iOSSimPortable's fibers module.
+	var pathToUpperLevelNodeModulesDir = path.join(__dirname, ".."),
+		pathToUpperLevelFibersDir = path.join(pathToUpperLevelNodeModulesDir, fibersDirName);
+
+	var nodeModulesStat = fs.statSync(pathToUpperLevelNodeModulesDir),
+		fibersStat = fs.statSync(pathToUpperLevelFibersDir);
+
+	if (nodeModulesStat.isDirectory() && path.basename(pathToUpperLevelNodeModulesDir) === nodeModulesDirName && fibersStat.isDirectory()) {
+		shelljs.rm("-rf", path.join(__dirname, nodeModulesDirName, fibersDirName));
+	}
+} catch (err) {
+	// Ignore the error. Most probably ios-sim-portable is not used as dependency, so we should not delete anything.
+}


### PR DESCRIPTION
When ios-sim-portable is used as dependency of any module that has fibers, the fibers in ios-sim-portable conflict at runtime with the original package's fibers.
So add postinstall script to check if there are fibers in the upper level dir and upper level dir is called node_modules. If these circumstances are fulfilled, remove the ios-sim-portable's fibers directory - let's use original package's fibers module.