### PR TITLE
Add --sdk as parameter

### DIFF
--- a/lib/iphone-interop-simulator-base.ts
+++ b/lib/iphone-interop-simulator-base.ts
@@ -84,7 +84,8 @@ export class IPhoneInteropSimulatorBase extends IPhoneSimulatorNameGetter {
 		config("setApplicationToSimulateOnStart",  appSpec);
 		config("setSimulatedApplicationShouldWaitForDebugger", options.waitForDebugger);
 
-		let sdkRoot = options.sdkVersion ? $(this.getSdkRootPathByVersion(options.sdkVersion)) : this.getClassByName("DTiPhoneSimulatorSystemRoot")("defaultRoot");
+		let sdkVersion = options.sdkVersion || options.sdk;
+		let sdkRoot = sdkVersion ? $(this.getSdkRootPathByVersion(sdkVersion)) : this.getClassByName("DTiPhoneSimulatorSystemRoot")("defaultRoot");
 		config("setSimulatedSystemRoot", sdkRoot);
 
 		this.validateDevice();

--- a/lib/iphone-simulator-xcode-7.ts
+++ b/lib/iphone-simulator-xcode-7.ts
@@ -104,21 +104,23 @@ export class XCode7Simulator extends IPhoneSimulatorNameGetter implements ISimul
 
 	private getDeviceToRun(): IFuture<IDevice> {
 		return (() => {
-			let devices = this.simctl.getDevices().wait();
+			let devices = this.simctl.getDevices().wait(),
+				sdkVersion = options.sdkVersion || options.sdk;
+
 			let result = _.find(devices, (device: IDevice) => {
-				if(options.sdkVersion && !options.device) {
-					return device.runtimeVersion === options.sdkVersion;
+				if(sdkVersion && !options.device) {
+					return device.runtimeVersion === sdkVersion;
 				}
 
-				if(options.device && !options.sdkVersion) {
+				if(options.device && !sdkVersion) {
 					return device.name === options.device;
 				}
 
-				if(options.device && options.sdkVersion) {
-					return device.runtimeVersion === options.sdkVersion && device.name === options.device;
+				if(options.device && sdkVersion) {
+					return device.runtimeVersion === sdkVersion && device.name === options.device;
 				}
 
-				if(!options.sdkVersion && !options.device) {
+				if(!sdkVersion && !options.device) {
 					return this.isDeviceBooted(device);
 				}
 			});

--- a/lib/iphone-simulator.ts
+++ b/lib/iphone-simulator.ts
@@ -37,10 +37,11 @@ export class iPhoneSimulator implements IiPhoneSimulator {
 			}
 		}
 
-		if(options.sdkVersion) {
+		let sdkVersion = options.sdkVersion || options.sdk;
+		if(sdkVersion) {
 			let runtimeVersions = _.unique(_.map(this.simulator.getDevices().wait(), (device: IDevice) => device.runtimeVersion));
-			if(!_.contains(runtimeVersions, options.sdkVersion)) {
-				errors.fail(`Unable to find sdk ${options.sdkVersion}. The valid runtime versions are ${runtimeVersions.join(", ")}`);
+			if(!_.contains(runtimeVersions, sdkVersion)) {
+				errors.fail(`Unable to find sdk ${sdkVersion}. The valid runtime versions are ${runtimeVersions.join(", ")}`);
 			}
 		}
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -20,7 +20,8 @@ var knownOptions = {
     "help": { type: OptionType.Boolean },
     "logging": { type: OptionType.Boolean },
     "waitForDebugger": { type: OptionType.Boolean },
-    "sdkVersion": { type: OptionType.String }
+    "sdkVersion": { type: OptionType.String },
+    "sdk": { type: OptionType.String }
 };
 var parsed = {};
 var argv = yargs(process.argv.slice(2)).options(knownOptions).argv;

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -20,7 +20,8 @@ var knownOptions: any = {
 	"help": { type: OptionType.Boolean },
 	"logging": { type: OptionType.Boolean },
 	"waitForDebugger": { type: OptionType.Boolean },
-	"sdkVersion": { type: OptionType.String }
+	"sdkVersion": { type: OptionType.String }, // Obsolete, use sdk instead.
+	"sdk": { type: OptionType.String }
 };
 
 var parsed: any = {};


### PR DESCRIPTION
When CLI uses ios-sim-portable through require("ios-sim-portable"), this module must understand the same command line parameters as the one passed to NativeScript CLI / AppBuilder CLI.
The option there is called `--sdk`, while here it is `--sdkVersion`. Add `--sdk` here, so ios-sim-portable will pass it and use it to start the correct emulator.