### PR TITLE
Remove lodash from global object

### DIFF
--- a/lib/ios-sim.ts
+++ b/lib/ios-sim.ts
@@ -1,6 +1,7 @@
 ///<reference path="./.d.ts"/>
 "use strict";
-global._ = require("lodash");
+
+import * as _ from "lodash";
 
 import Fiber = require("fibers");
 import Future = require("fibers/future");

--- a/lib/iphone-interop-simulator-base.ts
+++ b/lib/iphone-interop-simulator-base.ts
@@ -10,6 +10,8 @@ import * as os from "os";
 import * as path from "path";
 import * as util from "util";
 import * as utils from "./utils";
+import * as _ from "lodash";
+
 let $ = require("nodobjc");
 import {IPhoneSimulatorNameGetter} from "./iphone-simulator-name-getter";
 

--- a/lib/iphone-simulator-common.ts
+++ b/lib/iphone-simulator-common.ts
@@ -7,6 +7,8 @@ import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 import xcode = require("./xcode");
+import * as _ from "lodash";
+
 let bplistParser = require("bplist-parser");
 let plist = require("plist");
 let osenv = require("osenv");

--- a/lib/iphone-simulator-xcode-5.ts
+++ b/lib/iphone-simulator-xcode-5.ts
@@ -6,6 +6,7 @@ import Future = require("fibers/future");
 import options = require("./options");
 import utils = require("./utils");
 import util = require("util");
+import * as _ from "lodash";
 
 var $ = require("nodobjc");
 

--- a/lib/iphone-simulator-xcode-6.ts
+++ b/lib/iphone-simulator-xcode-6.ts
@@ -10,6 +10,8 @@ import * as fs from "fs";
 import * as path from "path";
 import * as util from "util";
 import * as os from "os";
+import * as _ from "lodash";
+
 import common = require("./iphone-simulator-common");
 import { Simctl } from "./simctl";
 let $ = require("nodobjc");

--- a/lib/iphone-simulator-xcode-7.ts
+++ b/lib/iphone-simulator-xcode-7.ts
@@ -11,6 +11,7 @@ import { Simctl } from "./simctl";
 import util = require("util");
 import utils = require("./utils");
 import xcode = require("./xcode");
+import * as _ from "lodash";
 
 import {IPhoneSimulatorNameGetter} from "./iphone-simulator-name-getter";
 

--- a/lib/iphone-simulator.ts
+++ b/lib/iphone-simulator.ts
@@ -16,6 +16,8 @@ import xcode7SimulatorLib = require("./iphone-simulator-xcode-7");
 import xcode6SimulatorLib = require("./iphone-simulator-xcode-6");
 import xcode5SimulatorLib = require("./iphone-simulator-xcode-5");
 
+import * as _ from "lodash";
+
 var $ = require("nodobjc");
 
 export class iPhoneSimulator implements IiPhoneSimulator {

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,6 +1,7 @@
 ///<reference path=".d.ts"/>
 "use strict";
 var yargs = require("yargs");
+var _ = require("lodash");
 var OptionType = (function () {
     function OptionType() {
     }

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -2,6 +2,7 @@
 "use strict";
 
 var yargs = require("yargs");
+import * as _ from "lodash";
 
 class OptionType {
 	public static String = "string";

--- a/lib/simctl.ts
+++ b/lib/simctl.ts
@@ -5,6 +5,7 @@ import childProcess = require("./child-process");
 import future = require("fibers/future");
 import errors = require("./errors");
 import options = require("./options");
+import * as _ from "lodash";
 
 export class Simctl implements ISimctl {
 


### PR DESCRIPTION
When CLI require's ios-sim-portable, it already had added lodash in the global object. So ios-sim-portable resets it to the version specified in its own package.json, so CLI's code will no longer work.
Do not use the _ from the global object - require it in each file instead.