### PR TITLE
Fix prepublish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-sim-portable",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "",
   "main": "./lib/ios-sim.js",
   "scripts": {

--- a/prepublish.js
+++ b/prepublish.js
@@ -1,7 +1,11 @@
-var fs = require("fs");
-var grunt = require("grunt");
+var fs = require("fs"),
+	path = require("path"),
+	grunt = require("grunt");
 
-var callback = function(err) {};
+var pathToTypeScriptEntryPoint = path.join(__dirname, "lib", "ios-sim.ts");
+if (fs.existsSync(pathToTypeScriptEntryPoint)) {
+	var callback = function(err) {};
 
-grunt.cli.tasks = ["ts:devlib"];
-grunt.cli(null, callback);
+	grunt.cli.tasks = ["ts:devlib"];
+	grunt.cli(null, callback);
+}

--- a/prepublish.js
+++ b/prepublish.js
@@ -1,10 +1,10 @@
 var fs = require("fs"),
-	path = require("path"),
-	grunt = require("grunt");
+	path = require("path");
 
 var pathToTypeScriptEntryPoint = path.join(__dirname, "lib", "ios-sim.ts");
 if (fs.existsSync(pathToTypeScriptEntryPoint)) {
-	var callback = function(err) {};
+	var callback = function(err) {},
+		grunt = require("grunt");
 
 	grunt.cli.tasks = ["ts:devlib"];
 	grunt.cli(null, callback);


### PR DESCRIPTION
Fix prepublish script to transpile `.ts` files only when the ios-sim.ts file exists.
This will allow us to call `npm publish <path to ios-sim-portable.tgz>` without `--ignore-scripts` option as it is removing all scripts from package.json section.