### PR TITLE
Add grunt pack command

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,6 +13,25 @@ module.exports = function(grunt) {
 			devlib: {
 				src: ["lib/**/*.ts"],
 				reference: "lib/.d.ts"
+			},
+			release_build: {
+				src: ["lib/**/*.ts"],
+				reference: "lib/.d.ts",
+				options: {
+					sourceMap: false,
+					removeComments: true
+				}
+			}
+		},
+
+		shell: {
+			options: {
+				stdout: true,
+				stderr: true
+			},
+
+			build_package: {
+				command: "npm pack"
 			}
 		},
 
@@ -23,6 +42,20 @@ module.exports = function(grunt) {
 
 	grunt.loadNpmTasks("grunt-contrib-clean");
 	grunt.loadNpmTasks("grunt-ts");
+	grunt.loadNpmTasks('grunt-shell');
+
+	grunt.registerTask("remove_prepublish_script", function() {
+		var packageJson = grunt.file.readJSON("package.json");
+		delete packageJson.scripts.prepublish;
+		grunt.file.write("package.json", JSON.stringify(packageJson, null, "  "));
+	});
+
+	grunt.registerTask("pack", [
+		"clean",
+		"remove_prepublish_script",
+		"ts:release_build",
+		"shell:build_package"
+	]);
 
 	grunt.registerTask("default", "ts:devlib");
 }

--- a/package.json
+++ b/package.json
@@ -38,9 +38,10 @@
     "yargs": "4.7.1"
   },
   "devDependencies": {
-    "grunt-contrib-clean": "0.6.0",
-    "grunt": "0.4.5",
-    "grunt-ts": "4.2.0",
+    "grunt": "1.0.1",
+    "grunt-contrib-clean": "1.0.0",
+    "grunt-shell": "1.3.0",
+    "grunt-ts": "5.5.1",
     "typescript": "1.7.5"
   },
   "engines": {


### PR DESCRIPTION
Add grunt pack command that will:
* remove prepublish script from package.json
* clean the project (delete all .js files inside it)
* build .ts files in release mode
* call `npm pack` and produce .tgz for the new version

We have to remove the prepublish script as it does not allow us clean publish of the .tgz.
The problem is that when `npm publish <tgz>` is used, the package is added to local npm cache. After that it's package.json is extracted from the cached .tgz file and modified with additional metadata. At this point npm calls the prepublish script, but it fails to find our prepublish.js as it's not extracted in the cache (only the package.json is extracted).

I've not removed the prepublish script from the package.json, so if anyone uses `npm pack` locally or `npm publish` directly, the correct .js files will be used.

> NOTE: Calling `grunt pack` locally will modify your package.json. DO NOT commit these changes.