### PR TITLE
Return the child process of print device log

### DIFF
--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -55,7 +55,7 @@ interface ISimulator extends INameGetter {
 	uninstallApplication(deviceId: string, appIdentifier: string): IFuture<void>;
 	startApplication(deviceId: string, appIdentifier: string): IFuture<string>;
 	stopApplication(deviceId: string, appIdentifier: string): IFuture<string>;
-	printDeviceLog(deviceId: string, launchResult?: string): void;
+	printDeviceLog(deviceId: string, launchResult?: string): any;
 	startSimulator(): IFuture<void>;
 }
 

--- a/lib/iphone-simulator-xcode-5.ts
+++ b/lib/iphone-simulator-xcode-5.ts
@@ -52,7 +52,7 @@ export class XCode5Simulator extends iPhoneSimulatorBaseLib.IPhoneInteropSimulat
 		}).future<ISdk[]>()();
 	}
 
-	public setSimulatedDevice(config:any): void {
+	public setSimulatedDevice(config: any): void {
 		config("setSimulatedDeviceInfoName", $(this.deviceIdentifier));
 	}
 
@@ -84,7 +84,7 @@ export class XCode5Simulator extends iPhoneSimulatorBaseLib.IPhoneInteropSimulat
 		return Future.fromResult("");
 	}
 
-	public printDeviceLog(deviceId: string): void {	}
+	public printDeviceLog(deviceId: string): any { }
 
 	public startSimulator(): IFuture<void> {
 		return Future.fromResult();

--- a/lib/iphone-simulator-xcode-6.ts
+++ b/lib/iphone-simulator-xcode-6.ts
@@ -84,8 +84,8 @@ export class XCode6Simulator extends iPhoneSimulatorBaseLib.IPhoneInteropSimulat
 		}
 	}
 
-	public printDeviceLog(deviceId: string, launchResult?: string): void {
-		common.printDeviceLog(deviceId, launchResult);
+	public printDeviceLog(deviceId: string, launchResult?: string): any {
+		return common.printDeviceLog(deviceId, launchResult);
 	}
 
 	public startSimulator(): IFuture<void> {

--- a/lib/iphone-simulator-xcode-7.ts
+++ b/lib/iphone-simulator-xcode-7.ts
@@ -46,7 +46,7 @@ export class XCode7Simulator extends IPhoneSimulatorNameGetter implements ISimul
 		return (() => {
 			let device = this.getDeviceToRun().wait();
 			let currentBootedDevice = _.find(this.getDevices().wait(), device => this.isDeviceBooted(device));
-			if(currentBootedDevice && (currentBootedDevice.name.toLowerCase() !== device.name.toLowerCase() || currentBootedDevice.runtimeVersion !== device.runtimeVersion)) {
+			if (currentBootedDevice && (currentBootedDevice.name.toLowerCase() !== device.name.toLowerCase() || currentBootedDevice.runtimeVersion !== device.runtimeVersion)) {
 				this.killSimulator().wait();
 			}
 
@@ -86,7 +86,7 @@ export class XCode7Simulator extends IPhoneSimulatorNameGetter implements ISimul
 	}
 
 	public uninstallApplication(deviceId: string, appIdentifier: string): IFuture<void> {
-		return this.simctl.uninstall(deviceId, appIdentifier, {skipError: true});
+		return this.simctl.uninstall(deviceId, appIdentifier, { skipError: true });
 	}
 
 	public startApplication(deviceId: string, appIdentifier: string): IFuture<string> {
@@ -95,13 +95,13 @@ export class XCode7Simulator extends IPhoneSimulatorNameGetter implements ISimul
 
 	public stopApplication(deviceId: string, cfBundleExecutable: string): IFuture<string> {
 		try {
-			return childProcess.exec(`killall ${cfBundleExecutable}`, {skipError: true});
-		} catch(e) {
+			return childProcess.exec(`killall ${cfBundleExecutable}`, { skipError: true });
+		} catch (e) {
 		}
 	}
 
-	public printDeviceLog(deviceId: string, launchResult?: string): void {
-		common.printDeviceLog(deviceId, launchResult);
+	public printDeviceLog(deviceId: string, launchResult?: string): any {
+		return common.printDeviceLog(deviceId, launchResult);
 	}
 
 	private getDeviceToRun(): IFuture<IDevice> {
@@ -110,28 +110,28 @@ export class XCode7Simulator extends IPhoneSimulatorNameGetter implements ISimul
 				sdkVersion = options.sdkVersion || options.sdk;
 
 			let result = _.find(devices, (device: IDevice) => {
-				if(sdkVersion && !options.device) {
+				if (sdkVersion && !options.device) {
 					return device.runtimeVersion === sdkVersion;
 				}
 
-				if(options.device && !sdkVersion) {
+				if (options.device && !sdkVersion) {
 					return device.name === options.device;
 				}
 
-				if(options.device && sdkVersion) {
+				if (options.device && sdkVersion) {
 					return device.runtimeVersion === sdkVersion && device.name === options.device;
 				}
 
-				if(!sdkVersion && !options.device) {
+				if (!sdkVersion && !options.device) {
 					return this.isDeviceBooted(device);
 				}
 			});
 
-			if(!result) {
+			if (!result) {
 				result = _.find(devices, (device: IDevice) => device.name === this.defaultDeviceIdentifier);
 			}
 
-			if(!result) {
+			if (!result) {
 				let sortedDevices = _.sortBy(devices, (device) => device.runtimeVersion);
 				result = _.last(sortedDevices);
 			}

--- a/lib/iphone-simulator-xcode-8.ts
+++ b/lib/iphone-simulator-xcode-8.ts
@@ -46,7 +46,7 @@ export class XCode8Simulator extends IPhoneSimulatorNameGetter implements ISimul
 		return (() => {
 			let device = this.getDeviceToRun().wait();
 			let currentBootedDevice = _.find(this.getDevices().wait(), device => this.isDeviceBooted(device));
-			if(currentBootedDevice && (currentBootedDevice.name.toLowerCase() !== device.name.toLowerCase() || currentBootedDevice.runtimeVersion !== device.runtimeVersion)) {
+			if (currentBootedDevice && (currentBootedDevice.name.toLowerCase() !== device.name.toLowerCase() || currentBootedDevice.runtimeVersion !== device.runtimeVersion)) {
 				this.killSimulator().wait();
 			}
 
@@ -86,7 +86,7 @@ export class XCode8Simulator extends IPhoneSimulatorNameGetter implements ISimul
 	}
 
 	public uninstallApplication(deviceId: string, appIdentifier: string): IFuture<void> {
-		return this.simctl.uninstall(deviceId, appIdentifier, {skipError: true});
+		return this.simctl.uninstall(deviceId, appIdentifier, { skipError: true });
 	}
 
 	public startApplication(deviceId: string, appIdentifier: string): IFuture<string> {
@@ -95,13 +95,13 @@ export class XCode8Simulator extends IPhoneSimulatorNameGetter implements ISimul
 
 	public stopApplication(deviceId: string, cfBundleExecutable: string): IFuture<string> {
 		try {
-			return childProcess.exec(`killall ${cfBundleExecutable}`, {skipError: true});
-		} catch(e) {
+			return childProcess.exec(`killall ${cfBundleExecutable}`, { skipError: true });
+		} catch (e) {
 		}
 	}
 
-	public printDeviceLog(deviceId: string, launchResult?: string): void {
-		common.printDeviceLog(deviceId, launchResult);
+	public printDeviceLog(deviceId: string, launchResult?: string): any {
+		return common.printDeviceLog(deviceId, launchResult);
 	}
 
 	private getDeviceToRun(): IFuture<IDevice> {
@@ -110,28 +110,28 @@ export class XCode8Simulator extends IPhoneSimulatorNameGetter implements ISimul
 				sdkVersion = options.sdkVersion || options.sdk;
 
 			let result = _.find(devices, (device: IDevice) => {
-				if(sdkVersion && !options.device) {
+				if (sdkVersion && !options.device) {
 					return device.runtimeVersion === sdkVersion;
 				}
 
-				if(options.device && !sdkVersion) {
+				if (options.device && !sdkVersion) {
 					return device.name === options.device;
 				}
 
-				if(options.device && sdkVersion) {
+				if (options.device && sdkVersion) {
 					return device.runtimeVersion === sdkVersion && device.name === options.device;
 				}
 
-				if(!sdkVersion && !options.device) {
+				if (!sdkVersion && !options.device) {
 					return this.isDeviceBooted(device);
 				}
 			});
 
-			if(!result) {
+			if (!result) {
 				result = _.find(devices, (device: IDevice) => device.name === this.defaultDeviceIdentifier);
 			}
 
-			if(!result) {
+			if (!result) {
 				let sortedDevices = _.sortBy(devices, (device) => device.runtimeVersion);
 				result = _.last(sortedDevices);
 			}


### PR DESCRIPTION
If someone wants to use the child process which is used to get the device log we need to return it when the printDeviceLog method is called.