### PR TITLE
Return simulator log to caller and do not filter the output

### DIFF
--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -56,6 +56,7 @@ interface ISimulator extends INameGetter {
 	startApplication(deviceId: string, appIdentifier: string): IFuture<string>;
 	stopApplication(deviceId: string, appIdentifier: string): IFuture<string>;
 	printDeviceLog(deviceId: string, launchResult?: string): any;
+	getDeviceLogProcess(deviceId: string): any;
 	startSimulator(): IFuture<void>;
 }
 

--- a/lib/ios-sim.ts
+++ b/lib/ios-sim.ts
@@ -72,6 +72,7 @@ Object.defineProperty(global.publicApi, "getInstalledApplications", {
  "startApplication",
  "stopApplication",
  "printDeviceLog",
+ "getDeviceLogProcess",
  "startSimulator",
  "getSimulatorName"].forEach(methodName => {
 	Object.defineProperty(global.publicApi, methodName, {

--- a/lib/iphone-simulator-common.ts
+++ b/lib/iphone-simulator-common.ts
@@ -48,8 +48,7 @@ export function printDeviceLog(deviceId: string, launchResult?: string): any {
 	}
 
 	if (!isDeviceLogOperationStarted) {
-		let logFilePath = path.join(osenv.home(), "Library", "Logs", "CoreSimulator", deviceId, "system.log");
-		deviceLogChildProcess = require("child_process").spawn("tail", ['-f', '-n', '1', logFilePath]);
+		deviceLogChildProcess = this.getDeviceLogProcess(deviceId);
 		if (deviceLogChildProcess.stdout) {
 			deviceLogChildProcess.stdout.on("data", (data: NodeBuffer) => {
 				let dataAsString = data.toString();
@@ -76,7 +75,15 @@ export function printDeviceLog(deviceId: string, launchResult?: string): any {
 				process.stdout.write(data.toString());
 			});
 		}
+	}
 
+	return deviceLogChildProcess;
+}
+
+export function getDeviceLogProcess(deviceId: string): any {
+	if (!isDeviceLogOperationStarted) {
+		let logFilePath = path.join(osenv.home(), "Library", "Logs", "CoreSimulator", deviceId, "system.log");
+		deviceLogChildProcess = require("child_process").spawn("tail", ['-f', '-n', '1', logFilePath]);
 		isDeviceLogOperationStarted = true;
 	}
 

--- a/lib/iphone-simulator-xcode-5.ts
+++ b/lib/iphone-simulator-xcode-5.ts
@@ -86,6 +86,8 @@ export class XCode5Simulator extends iPhoneSimulatorBaseLib.IPhoneInteropSimulat
 
 	public printDeviceLog(deviceId: string): any { }
 
+	public getDeviceLogProcess(deviceId: string): any { }
+
 	public startSimulator(): IFuture<void> {
 		return Future.fromResult();
 	}

--- a/lib/iphone-simulator-xcode-6.ts
+++ b/lib/iphone-simulator-xcode-6.ts
@@ -88,6 +88,10 @@ export class XCode6Simulator extends iPhoneSimulatorBaseLib.IPhoneInteropSimulat
 		return common.printDeviceLog(deviceId, launchResult);
 	}
 
+	public getDeviceLogProcess(deviceId: string): any {
+		return common.getDeviceLogProcess(deviceId);
+	}
+
 	public startSimulator(): IFuture<void> {
 		let device = this.devices[0];
 		return common.startSimulator(device.id);

--- a/lib/iphone-simulator-xcode-7.ts
+++ b/lib/iphone-simulator-xcode-7.ts
@@ -104,6 +104,10 @@ export class XCode7Simulator extends IPhoneSimulatorNameGetter implements ISimul
 		return common.printDeviceLog(deviceId, launchResult);
 	}
 
+	public getDeviceLogProcess(deviceId: string): any {
+		return common.getDeviceLogProcess(deviceId);
+	}
+
 	private getDeviceToRun(): IFuture<IDevice> {
 		return (() => {
 			let devices = this.simctl.getDevices().wait(),

--- a/lib/iphone-simulator-xcode-8.ts
+++ b/lib/iphone-simulator-xcode-8.ts
@@ -104,6 +104,10 @@ export class XCode8Simulator extends IPhoneSimulatorNameGetter implements ISimul
 		return common.printDeviceLog(deviceId, launchResult);
 	}
 
+	public getDeviceLogProcess(deviceId: string): any {
+		return common.getDeviceLogProcess(deviceId);
+	}
+
 	private getDeviceToRun(): IFuture<IDevice> {
 		return (() => {
 			let devices = this.simctl.getDevices().wait(),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-sim-portable",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "",
   "main": "./lib/ios-sim.js",
   "scripts": {


### PR DESCRIPTION
Add `getDeviceLogProcess` method that returns child_process for device logs to the caller and let it decide how to hanlde the logging operations.