### PR TITLE
Modify startSimulator to kill the booted one if it's not with the sam…

### DIFF
--- a/lib/iphone-simulator-xcode-simctl.ts
+++ b/lib/iphone-simulator-xcode-simctl.ts
@@ -40,11 +40,11 @@ export class XCodeSimctlSimulator extends IPhoneSimulatorNameGetter implements I
 		});
 	}
 
-	public run(applicationPath: string, applicationIdentifier: string): void {
+	public async run(applicationPath: string, applicationIdentifier: string): void {
 		let device = this.getDeviceToRun();
 		let currentBootedDevice = _.find(this.getDevices(), device => this.isDeviceBooted(device));
 		if (currentBootedDevice && (currentBootedDevice.name.toLowerCase() !== device.name.toLowerCase() || currentBootedDevice.runtimeVersion !== device.runtimeVersion)) {
-			this.killSimulator();
+			await this.killSimulator();
 		}
 
 		this.startSimulator(device);
@@ -145,9 +145,14 @@ export class XCodeSimctlSimulator extends IPhoneSimulatorNameGetter implements I
 		return _.find(devices, device => this.isDeviceBooted(device));
 	}
 
-	public startSimulator(device?: IDevice): void {
+	public async startSimulator(device?: IDevice): void {
 		device = device || this.getDeviceToRun();
 		if (!this.isDeviceBooted(device)) {
+			let bootedDevice = this.getBootedDevice();
+			if(bootedDevice && bootedDevice.id !== device.id) {
+				await this.killSimulator();
+			}
+
 			common.startSimulator(device.id);
 			// startSimulaltor doesn't always finish immediately, and the subsequent
 			// install fails since the simulator is not running.
@@ -156,7 +161,7 @@ export class XCodeSimctlSimulator extends IPhoneSimulatorNameGetter implements I
 		}
 	}
 
-	private killSimulator(): Promise<any> {
+	private async killSimulator(): Promise<any> {
 		return childProcess.spawn("pkill", ["-9", "-f", "Simulator"]);
 	}
 }

--- a/lib/iphone-simulator-xcode-simctl.ts
+++ b/lib/iphone-simulator-xcode-simctl.ts
@@ -40,11 +40,11 @@ export class XCodeSimctlSimulator extends IPhoneSimulatorNameGetter implements I
 		});
 	}
 
-	public async run(applicationPath: string, applicationIdentifier: string): void {
+	public run(applicationPath: string, applicationIdentifier: string): void {
 		let device = this.getDeviceToRun();
 		let currentBootedDevice = _.find(this.getDevices(), device => this.isDeviceBooted(device));
 		if (currentBootedDevice && (currentBootedDevice.name.toLowerCase() !== device.name.toLowerCase() || currentBootedDevice.runtimeVersion !== device.runtimeVersion)) {
-			await this.killSimulator();
+			this.killSimulator();
 		}
 
 		this.startSimulator(device);
@@ -145,23 +145,23 @@ export class XCodeSimctlSimulator extends IPhoneSimulatorNameGetter implements I
 		return _.find(devices, device => this.isDeviceBooted(device));
 	}
 
-	public async startSimulator(device?: IDevice): void {
+	public startSimulator(device?: IDevice): void {
 		device = device || this.getDeviceToRun();
 		if (!this.isDeviceBooted(device)) {
 			let bootedDevice = this.getBootedDevice();
 			if(bootedDevice && bootedDevice.id !== device.id) {
-				await this.killSimulator();
+				 this.killSimulator();
 			}
 
 			common.startSimulator(device.id);
 			// startSimulaltor doesn't always finish immediately, and the subsequent
 			// install fails since the simulator is not running.
 			// Give it some time to start before we attempt installing.
-			utils.sleep(1000);
+			utils.sleep(1000); 
 		}
 	}
-
-	private async killSimulator(): Promise<any> {
-		return childProcess.spawn("pkill", ["-9", "-f", "Simulator"]);
+ 
+	private killSimulator(): Promise<any> {
+		childProcess.execSync("pkill -9 -f Simulator");
 	}
 }


### PR DESCRIPTION
Modify the startSimulator method to ensure if there's an already running Simulator that it's the same as the requested by the user. If it's not, it kills it first and the starts the new one with the correct DeviceId.