### PR TITLE
Ensure stopApplication works correctly

### DIFF
--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -28,6 +28,7 @@ interface IDevice {
 
 interface ISimctl {
 	launch(deviceId: string, applicationIdentifier: string): string;
+	terminate(deviceId: string, appIdentifier: string): string;
 	install(deviceId: string, applicationPath: string): void;
 	uninstall(deviceId: string, applicationIdentifier: string, opts?: any): void;
 	notifyPost(deviceId: string, notification: string): void;
@@ -49,7 +50,7 @@ interface ISimulator extends INameGetter {
 	installApplication(deviceId: string, applicationPath: string): void;
 	uninstallApplication(deviceId: string, appIdentifier: string): void;
 	startApplication(deviceId: string, appIdentifier: string): string;
-	stopApplication(deviceId: string, appIdentifier: string): string;
+	stopApplication(deviceId: string, appIdentifier: string, bundleExecutable: string): string;
 	printDeviceLog(deviceId: string, launchResult?: string): any;
 	getDeviceLogProcess(deviceId: string): any;
 	startSimulator(): void;

--- a/lib/simctl.ts
+++ b/lib/simctl.ts
@@ -27,6 +27,10 @@ export class Simctl implements ISimctl {
 		return result;
 	}
 
+	public terminate(deviceId: string, appIdentifier: string): string {
+		return this.simctlExec("terminate", [deviceId, appIdentifier]);
+	}
+
 	public install(deviceId: string, applicationPath: string): void {
 		return this.simctlExec("install", [deviceId, applicationPath]);
 	}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,3 +1,5 @@
+import * as childProcess from "./child-process";
+
 export function stringify(arr: string[], delimiter?: string): string {
 	delimiter = delimiter || ", ";
 	return arr.join(delimiter);
@@ -8,10 +10,6 @@ export function getCurrentEpochTime(): number {
 	return dateTime.getTime();
 }
 
-export function sleep(ms: number): void {
-	let startTime = getCurrentEpochTime();
-	let currentTime = getCurrentEpochTime();
-	while ((currentTime - startTime) < ms) {
-		currentTime = getCurrentEpochTime();
-	}
+export function sleep(seconds: number): void {
+	childProcess.execSync(`sleep ${seconds}`);
 }

--- a/lib/xcode.ts
+++ b/lib/xcode.ts
@@ -6,7 +6,7 @@ export function getPathFromXcodeSelect(): string {
 
 export function getXcodeVersionData(): IXcodeVersionData {
 	let rawData = childProcess.execSync("xcodebuild -version");
-	let lines = rawData.split("\n");
+	let lines = rawData.toString().split("\n");
 	let parts = lines[0].split(" ")[1].split(".");
 	return {
 		major: parts[0],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-sim-portable",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "description": "",
   "main": "./lib/ios-sim.js",
   "scripts": {


### PR DESCRIPTION
`stopApplication` method calls `killall` command, which does not terminate the process immediately. So trying to restart the application, which is `stopApplication` followed by immediate `startApplication` call, fails with some strange error, that the `app has started, but has exited since then`. In order to fix this, add a timeout after stop is called, in order to ensure the app is dead. However in newer Xcode's there's a `xcrun simctl terminate` command, which really kills it.
So check the version of Xcode and in case it is 8 or later, use the new command instead of killall. In this scenario we do not have to add some magic timeout as the command works correctly.
However the xcrun simctl terminate command requires application identifier, while the killall command works with application name. So I've added another paramter to the stopApplication definition, which should be passed from CLI when calling this method - the applicationIdentifier will be used when Xcode 8 or later is installed, appName will be used for earlier versions.