### PR TITLE
Fix restarting of application on simulator with OS < 10

### DIFF
--- a/lib/iphone-simulator-xcode-simctl.ts
+++ b/lib/iphone-simulator-xcode-simctl.ts
@@ -97,16 +97,20 @@ export class XCodeSimctlSimulator extends IPhoneSimulatorNameGetter implements I
 				// Ignore the error.
 			}
 
+			let resultOfTermination: string;
 			if (xcodeMajorVersion && xcodeMajorVersion < 8) {
 				// Xcode 7.x does not have support for `xcrun simctl terminate` command
-				const resultOfKill = childProcess.execSync(`killall ${bundleExecutable}`, { skipError: true });
-				// killall command does not terminate the processes immediately and we have to wait a little bit,
-				// just to ensure all related processes and services are dead.
-				utils.sleep(0.5);
-				return resultOfKill;
+				resultOfTermination = childProcess.execSync(`killall ${bundleExecutable}`, { skipError: true });
 			} else {
-				return this.simctl.terminate(deviceId, appIdentifier);
+				resultOfTermination = this.simctl.terminate(deviceId, appIdentifier);
 			}
+
+			// killall command does not terminate the processes immediately and we have to wait a little bit,
+			// just to ensure all related processes and services are dead.
+			// Same is valid for simctl terminate when Simulator's OS version is below 10.
+			utils.sleep(0.5);
+
+			return resultOfTermination;
 		} catch (e) {
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-sim-portable",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "",
   "main": "./lib/ios-sim.js",
   "scripts": {


### PR DESCRIPTION
In case the OS version of the simulated device is below 10, (for example 8.4) the `simctl terminate` does not kill the app immediately, so we kill it after we've called start.
Fix this by waiting 500 ms.