### PR TITLE
Fix log in iOS11 simulators.

### DIFF
--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -33,6 +33,7 @@ interface ISimctl {
 	uninstall(deviceId: string, applicationIdentifier: string, opts?: any): void;
 	notifyPost(deviceId: string, notification: string): void;
 	getDevices(): IDevice[];
+	getLog(deviceId: string): any;
 	getAppContainer(deviceId: string, applicationIdentifier: string): string;
 }
 

--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -33,7 +33,7 @@ interface ISimctl {
 	uninstall(deviceId: string, applicationIdentifier: string, opts?: any): void;
 	notifyPost(deviceId: string, notification: string): void;
 	getDevices(): IDevice[];
-	getLog(deviceId: string): any;
+	getLog(deviceId: string, predicate?: string): any;
 	getAppContainer(deviceId: string, applicationIdentifier: string): string;
 }
 

--- a/lib/iphone-simulator-common.ts
+++ b/lib/iphone-simulator-common.ts
@@ -36,54 +36,6 @@ export function getInstalledApplications(deviceId: string): IApplication[] {
 	return result;
 }
 
-export function printDeviceLog(deviceId: string, launchResult?: string): any {
-	if (launchResult) {
-		pid = launchResult.split(":")[1].trim();
-	}
-
-	if (!isDeviceLogOperationStarted) {
-		deviceLogChildProcess = this.getDeviceLogProcess(deviceId);
-		if (deviceLogChildProcess.stdout) {
-			deviceLogChildProcess.stdout.on("data", (data: NodeBuffer) => {
-				let dataAsString = data.toString();
-				if (pid) {
-					if (dataAsString.indexOf(`[${pid}]`) > -1) {
-						process.stdout.write(dataAsString);
-					}
-				} else {
-					process.stdout.write(dataAsString);
-				}
-			});
-		}
-
-		if (deviceLogChildProcess.stderr) {
-			deviceLogChildProcess.stderr.on("data", (data: string) => {
-				let dataAsString = data.toString();
-				if (pid) {
-					if (dataAsString.indexOf(`[${pid}]`) > -1) {
-						process.stdout.write(dataAsString);
-					}
-				} else {
-					process.stdout.write(dataAsString);
-				}
-				process.stdout.write(data.toString());
-			});
-		}
-	}
-
-	return deviceLogChildProcess;
-}
-
-export function getDeviceLogProcess(deviceId: string): any {
-	if (!isDeviceLogOperationStarted) {
-		let logFilePath = path.join(osenv.home(), "Library", "Logs", "CoreSimulator", deviceId, "system.log");
-		deviceLogChildProcess = require("child_process").spawn("tail", ['-f', '-n', '1', logFilePath]);
-		isDeviceLogOperationStarted = true;
-	}
-
-	return deviceLogChildProcess;
-}
-
 export function startSimulator(deviceId: string): void {
 	let simulatorPath = path.resolve(xcode.getPathFromXcodeSelect(), "Applications", "Simulator.app");
 	let args = ["open", simulatorPath, '--args', '-CurrentDeviceUDID', deviceId];

--- a/lib/simctl.ts
+++ b/lib/simctl.ts
@@ -1,4 +1,5 @@
 import childProcess = require("./child-process");
+import * as child_process from "child_process";
 import errors = require("./errors");
 import options = require("./options");
 import * as _ from "lodash";
@@ -120,6 +121,10 @@ export class Simctl implements ISimctl {
 		return devices;
 	}
 
+	public getLog(deviceId: string): any {
+		return this.simctlSpawn("spawn", [deviceId, "log", "stream"]);
+	}
+
 	private simctlExec(command: string, args: string[], opts?: any): string {
 		const result = childProcess.spawnSync("xcrun", ["simctl", command].concat(args), opts);
 		if (result) {
@@ -135,5 +140,9 @@ export class Simctl implements ISimctl {
 		}
 
 		return '';
+	}
+
+	private simctlSpawn(command: string, args: string[], opts?: any): any {
+		return child_process.spawn("xcrun", ["simctl", command].concat(args), opts);
 	}
 }

--- a/lib/simctl.ts
+++ b/lib/simctl.ts
@@ -121,8 +121,14 @@ export class Simctl implements ISimctl {
 		return devices;
 	}
 
-	public getLog(deviceId: string): any {
-		return this.simctlSpawn("spawn", [deviceId, "log", "stream"]);
+	public getLog(deviceId: string, predicate?: string): child_process.ChildProcess {
+		let predicateArgs: string[] = [];
+
+		if (predicate) {
+			predicateArgs = ["--predicate", predicate];
+		}
+
+		return this.simctlSpawn("spawn", [deviceId, "log", "stream", "--style", "syslog"].concat(predicateArgs));
 	}
 
 	private simctlExec(command: string, args: string[], opts?: any): string {
@@ -142,7 +148,7 @@ export class Simctl implements ISimctl {
 		return '';
 	}
 
-	private simctlSpawn(command: string, args: string[], opts?: any): any {
+	private simctlSpawn(command: string, args: string[], opts?: child_process.SpawnOptions): child_process.ChildProcess {
 		return child_process.spawn("xcrun", ["simctl", command].concat(args), opts);
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-sim-portable",
-  "version": "3.1.3",
+  "version": "3.2.0",
   "description": "",
   "main": "./lib/ios-sim.js",
   "scripts": {


### PR DESCRIPTION
Part of the fix https://github.com/NativeScript/nativescript-cli/issues/3141#issuecomment-333761544

Fix uses the method described in [this example](https://developer.apple.com/library/content/samplecode/Logging/Listings/Paper_Company_ReadMe_md.html#//apple_ref/doc/uid/TP40017510-Paper_Company_ReadMe_md-DontLinkElementID_11).