### PR TITLE
Fix killing simctl process capturing the kill signal without sending to parent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-sim-portable",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "",
   "main": "./lib/ios-sim.js",
   "scripts": {


### PR DESCRIPTION
In case when ios-sim-portable is used as a library, in a CLI for example, sending Ctrl + C should kill the CLI process and its related resources.
However, in case the code is currently executing `xcrun simctl` command, sending Ctrl + C does not kill the CLI process. There are two reasons for this:
* we use Node.js's `child_process.spawnSync` method to call `xcrun simctl` commands
* simctl handles the killing signals in its own manner

When the executable passed to spawnSync method has its own logic for handling Signals for termination, Node.js process does not receive the Signals. That's why, the spawned process just exits and CLI's code continues.
However, the returned result has a signal property showing the signal used to kill the process.
In order to send the same signal to CLI, just check if the `signal` property is set and send it to the current Node.js process as well.

Fixes https://github.com/NativeScript/nativescript-cli/issues/3016