### PR TITLE
Get debugger port from device logs

### DIFF
--- a/lib/commands/launch.ts
+++ b/lib/commands/launch.ts
@@ -1,8 +1,9 @@
 import iphoneSimulatorLibPath = require("./../iphone-simulator");
+import options = require("../options");
 
 export class Command implements ICommand {
-	public execute(args: string[]): void {
+	public execute(args: string[]): string {
 		var iphoneSimulator = new iphoneSimulatorLibPath.iPhoneSimulator();
-		return iphoneSimulator.run(args[0], args[1]);
+		return iphoneSimulator.run(args[0], args[1], options);
 	}
 }

--- a/lib/commands/notify-post.ts
+++ b/lib/commands/notify-post.ts
@@ -3,6 +3,6 @@ import iphoneSimulatorLibPath = require("./../iphone-simulator");
 export class Command implements ICommand {
 	public execute(args: string[]): void {
 		var iphoneSimulator = new iphoneSimulatorLibPath.iPhoneSimulator();
-		return iphoneSimulator.sendNotification(args[0]);
+		return iphoneSimulator.sendNotification(args[0], args[1]);
 	}
 }

--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -2,10 +2,10 @@
 "use strict";
 
 interface IiPhoneSimulator {
-	run(applicationPath: string, applicationIdentifier: string): void;
+	run(applicationPath: string, applicationIdentifier: string, options: IOptions): string;
 	printDeviceTypes(): void;
 	printSDKS(): void;
-	sendNotification(notification: string): void;
+	sendNotification(notification: string, deviceId: string): void;
 	createSimulator(): ISimulator;
 }
 
@@ -27,7 +27,7 @@ interface IDevice {
 }
 
 interface ISimctl {
-	launch(deviceId: string, applicationIdentifier: string): string;
+	launch(deviceId: string, applicationIdentifier: string, options: IOptions): string;
 	boot(deviceId: string): void;
 	terminate(deviceId: string, appIdentifier: string): string;
 	install(deviceId: string, applicationPath: string): void;
@@ -45,17 +45,16 @@ interface IDictionary<T> {
 interface ISimulator extends INameGetter {
 	getDevices(): IDevice[];
 	getSdks(): ISdk[];
-	run(applicationPath: string, applicationIdentifier: string): void;
-	sendNotification(notification: string): void;
+	run(applicationPath: string, applicationIdentifier: string, options: IOptions): string;
+	sendNotification(notification: string, deviceId: string): void;
 	getApplicationPath(deviceId: string, applicationIdentifier: string): string;
 	getInstalledApplications(deviceId: string): IApplication[];
 	installApplication(deviceId: string, applicationPath: string): void;
 	uninstallApplication(deviceId: string, appIdentifier: string): void;
-	startApplication(deviceId: string, appIdentifier: string): string;
+	startApplication(deviceId: string, appIdentifier: string, options: IOptions): string;
 	stopApplication(deviceId: string, appIdentifier: string, bundleExecutable: string): string;
-	printDeviceLog(deviceId: string, launchResult?: string): any;
 	getDeviceLogProcess(deviceId: string): any;
-	startSimulator(): void;
+	startSimulator(options: IOptions, device?: IDevice): void;
 }
 
 interface INameGetter {
@@ -84,4 +83,13 @@ interface IXcodeVersionData {
 	major: string;
 	minor: string;
 	build: string;
+}
+
+interface IOptions {
+	skipInstall?: boolean;
+	waitForDebugger?: boolean;
+	args?: any;
+	sdkVersion?: string;
+	sdk?: string;
+	device?: string;
 }

--- a/lib/ios-sim.ts
+++ b/lib/ios-sim.ts
@@ -75,15 +75,36 @@ Object.defineProperty(publicApi, "getInstalledApplications", {
 	}
 });
 
+Object.defineProperty(publicApi, "launchApplication", {
+	get: () => {
+		return (...args: any[]) => {
+			let libraryPath = require("./iphone-simulator");
+			let obj = new libraryPath.iPhoneSimulator();
+			return obj.run.apply(obj, args);
+		}
+	}
+});
+
+Object.defineProperty(publicApi, "printDeviceTypes", {
+	get: () => {
+		return (...args: any[]) => {
+			let libraryPath = require("./iphone-simulator");
+			let obj = new libraryPath.iPhoneSimulator();
+			return obj.printDeviceTypes.apply(obj, args);
+		}
+	}
+});
+
 ["installApplication",
 	"uninstallApplication",
 	"startApplication",
 	"stopApplication",
-	"printDeviceLog",
+	"run",
 	"getDeviceLogProcess",
 	"startSimulator",
 	"getSimulatorName",
-	"getDevices"].forEach(methodName => {
+	"getDevices",
+	"sendNotification"].forEach(methodName => {
 		Object.defineProperty(publicApi, methodName, {
 			get: () => {
 				return (...args: any[]) => {

--- a/lib/ios-sim.ts
+++ b/lib/ios-sim.ts
@@ -78,8 +78,8 @@ Object.defineProperty(publicApi, "getInstalledApplications", {
 Object.defineProperty(publicApi, "launchApplication", {
 	get: () => {
 		return (...args: any[]) => {
-			let libraryPath = require("./iphone-simulator");
-			let obj = new libraryPath.iPhoneSimulator();
+			const libraryPath = require("./iphone-simulator");
+			const obj = new libraryPath.iPhoneSimulator();
 			return obj.run.apply(obj, args);
 		}
 	}
@@ -88,8 +88,8 @@ Object.defineProperty(publicApi, "launchApplication", {
 Object.defineProperty(publicApi, "printDeviceTypes", {
 	get: () => {
 		return (...args: any[]) => {
-			let libraryPath = require("./iphone-simulator");
-			let obj = new libraryPath.iPhoneSimulator();
+			const libraryPath = require("./iphone-simulator");
+			const obj = new libraryPath.iPhoneSimulator();
 			return obj.printDeviceTypes.apply(obj, args);
 		}
 	}

--- a/lib/iphone-simulator-name-getter.ts
+++ b/lib/iphone-simulator-name-getter.ts
@@ -1,6 +1,5 @@
 ///<reference path="./.d.ts"/>
 "use strict";
-import * as options from "./options";
 
 export abstract class IPhoneSimulatorNameGetter implements INameGetter {
 	private _simulatorName: string;
@@ -9,7 +8,7 @@ export abstract class IPhoneSimulatorNameGetter implements INameGetter {
 
 	public getSimulatorName(deviceName?: string): string {
 		if (!this._simulatorName) {
-			this._simulatorName = options.device || deviceName || this.defaultDeviceIdentifier;
+			this._simulatorName = deviceName || this.defaultDeviceIdentifier;
 		}
 
 		return this._simulatorName;

--- a/lib/iphone-simulator.ts
+++ b/lib/iphone-simulator.ts
@@ -5,7 +5,6 @@ import path = require("path");
 import util = require("util");
 
 import errors = require("./errors");
-import options = require("./options");
 import xcode = require("./xcode");
 
 import { XCodeSimctlSimulator } from "./iphone-simulator-xcode-simctl";
@@ -19,7 +18,7 @@ export class iPhoneSimulator implements IiPhoneSimulator {
 		this.simulator = this.createSimulator();
 	}
 
-	public run(applicationPath: string, applicationIdentifier: string): void {
+	public run(applicationPath: string, applicationIdentifier: string, options: IOptions): string {
 		if (!fs.existsSync(applicationPath)) {
 			errors.fail("Path does not exist ", applicationPath);
 		}
@@ -39,7 +38,7 @@ export class iPhoneSimulator implements IiPhoneSimulator {
 			}
 		}
 
-		return this.simulator.run(applicationPath, applicationIdentifier);
+		return this.simulator.run(applicationPath, applicationIdentifier, options);
 	}
 
 	public printDeviceTypes(): void {
@@ -58,12 +57,12 @@ export class iPhoneSimulator implements IiPhoneSimulator {
 		});
 	}
 
-	public sendNotification(notification: string): void {
+	public sendNotification(notification: string, deviceId: string): void {
 		if (!notification) {
 			errors.fail("Notification required.");
 		}
 
-		return this.simulator.sendNotification(notification);
+		return this.simulator.sendNotification(notification, deviceId);
 	}
 
 	public createSimulator(): ISimulator {

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -11,15 +11,9 @@ class OptionType {
 
 var knownOptions: any = {
 	"debug": { type: OptionType.Boolean },
-	"exit": { type: OptionType.Boolean },
 	"device": { type: OptionType.String },
-	"stdout": { type: OptionType.String },
-	"stderr": { type: OptionType.String },
-	"env": { type: OptionType.String },
 	"args": { type: OptionType.String },
-	"timeout": { type: OptionType.String },
 	"help": { type: OptionType.Boolean },
-	"logging": { type: OptionType.Boolean },
 	"waitForDebugger": { type: OptionType.Boolean },
 	"sdkVersion": { type: OptionType.String }, // Obsolete, use sdk instead.
 	"sdk": { type: OptionType.String },

--- a/lib/simctl.ts
+++ b/lib/simctl.ts
@@ -1,12 +1,12 @@
 import childProcess = require("./child-process");
 import * as child_process from "child_process";
 import errors = require("./errors");
-import options = require("./options");
 import * as _ from "lodash";
 
 export class Simctl implements ISimctl {
 
-	public launch(deviceId: string, appIdentifier: string): string {
+	public launch(deviceId: string, appIdentifier: string, options: IOptions): string {
+		options = options || {};
 		let args: string[] = [];
 		if (options.waitForDebugger) {
 			args.push("-w");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-sim-portable",
-  "version": "3.3.3",
+  "version": "3.4.0",
   "description": "",
   "main": "./lib/ios-sim.js",
   "scripts": {


### PR DESCRIPTION
## What is the current behavior?
The inspector listening socket is being closed 30 sec. after the last activity on it (opening, disconnection, etc). It had to be closed in order to have the hardcoded port number 18181
available for other apps after finishing (or never starting) a
debugging session. Without this timeout the first app that opened
the port would take it as long as it's running and would prevent
any subsequent debugging attempts of another app on the same iOS device;
or even the same app on another iOS Simulator on the same Mac machine.
This leads to unavailability to run fast sync on multiples simulators.

## What is the new behavior?
From now on, the port is printed from `ios-runtime` in devices logs. {N} CLI parses the logs and searches for specified string. The string should be in following format:
```
NativeScript debugger has opened inspector socket on port ${port} for ${appId}.
```

This will allow to connect the frontend at any moment after starting a debug session, instead of failing after the 30 seconds have elapsed.
 