### PR TITLE
fix: launchApplication fails when device identifier is passed

### DIFF
--- a/lib/iphone-simulator-xcode-simctl.ts
+++ b/lib/iphone-simulator-xcode-simctl.ts
@@ -45,11 +45,7 @@ export class XCodeSimctlSimulator extends IPhoneSimulatorNameGetter implements I
 	}
 
 	public run(applicationPath: string, applicationIdentifier: string, options: IOptions): string {
-		let device = this.getDeviceToRun(options);
-		let currentBootedDevice = _.find(this.getDevices(), device => this.isDeviceBooted(device));
-		if (currentBootedDevice && (currentBootedDevice.name.toLowerCase() !== device.name.toLowerCase() || currentBootedDevice.runtimeVersion !== device.runtimeVersion)) {
-			this.killSimulator();
-		}
+		const device = this.getDeviceToRun(options);
 
 		this.startSimulator(options, device);
 		if (!options.skipInstall) {
@@ -210,7 +206,7 @@ export class XCodeSimctlSimulator extends IPhoneSimulatorNameGetter implements I
 		if (!this.isDeviceBooted(device)) {
 			const isSimulatorAppRunning = this.isSimulatorAppRunning();
 			const haveBootedDevices = this.haveBootedDevices();
-				
+
 			if (isSimulatorAppRunning) {
 				// In case user closes simulator window but simulator app is still alive
 				if (!haveBootedDevices) {

--- a/lib/iphone-simulator.ts
+++ b/lib/iphone-simulator.ts
@@ -24,9 +24,9 @@ export class iPhoneSimulator implements IiPhoneSimulator {
 		}
 
 		if (options.device) {
-			let deviceNames = _.unique(_.map(this.simulator.getDevices(), (device: IDevice) => device.name));
-			if (!_.contains(deviceNames, options.device)) {
-				errors.fail(`Unable to find device ${options.device}. The valid device names are ${deviceNames.join(", ")}`);
+			const hasSuchDevice = _.find(this.simulator.getDevices(), device => device.name === options.device || device.id === options.device);
+			if (!hasSuchDevice) {
+				errors.fail(`Unable to find device ${options.device}.`);
 			}
 		}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-sim-portable",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "",
   "main": "./lib/ios-sim.js",
   "scripts": {


### PR DESCRIPTION
In case `launchApplication` is called with device identifier (instead of name), the validation fails as it expects a name. However, we already support starting and working with Id, so fix the validation.
Also, in the past there was only one instance of a simulator running. When you wanted to start application on another simulator, we were killing the existing one and starting the new one. This is no longer required as multiple iOS Simulators may be running simultaneously. So remove the logic for killing the simulator