### PR TITLE
fix: Do not wait 15 seconds to detect simulator

### DIFF
--- a/lib/ios-sim.ts
+++ b/lib/ios-sim.ts
@@ -55,7 +55,7 @@ Object.defineProperty(publicApi, "getRunningSimulators", {
 			return new Promise<any>((resolve, reject) => {
 				const libraryPath = require("./iphone-simulator-xcode-simctl");
 				const simulator = new libraryPath.XCodeSimctlSimulator();
-				
+
 				const tryGetBootedDevices = () => {
 					try {
 						return simulator.getBootedDevices.apply(simulator, args);
@@ -75,15 +75,13 @@ Object.defineProperty(publicApi, "getRunningSimulators", {
 				}
 
 				if (!isResolved && (!result || !result.length)) {
-					let repeatCount = 30;
-					const timer = setInterval(() => {
+					const timer = setTimeout(() => {
 						result = tryGetBootedDevices();
-						if (((result && result.length) || !repeatCount) && !isResolved) {
+
+						if (!isResolved) {
 							isResolved = true;
-							clearInterval(timer);
 							resolve(result);
 						}
-						repeatCount--;
 					}, 500);
 				}
 			});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-sim-portable",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "",
   "main": "./lib/ios-sim.js",
   "scripts": {


### PR DESCRIPTION
Currently when we want to detect iOS Simulators we have a setInterval that iterrates 30 times for 500ms.
When you do not have any iOS Simulator, this causes 15 seconds of waiting.
Just retry once and continue, if the simulators don't show up, well, they do not want to work with you.