### PR TITLE
Kddimtirov/add error handler spawn

### DIFF
--- a/lib/child-process.ts
+++ b/lib/child-process.ts
@@ -55,5 +55,9 @@ export function spawn(command: string, args: string[], opts?: any): Promise<stri
 				}
 			}
 		});
+
+		childProcess.on("error", (err) => {
+			reject(err);
+		});
 	});
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-sim-portable",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "",
   "main": "./lib/ios-sim.js",
   "scripts": {


### PR DESCRIPTION
If the `on.(error, () =>{})` is missing, an unhandled exception is thrown.