### PR TITLE
fix: unable to install application every other time with Xcode 10

### DIFF
--- a/lib/iphone-simulator-xcode-simctl.ts
+++ b/lib/iphone-simulator-xcode-simctl.ts
@@ -49,7 +49,7 @@ export class XCodeSimctlSimulator extends IPhoneSimulatorNameGetter implements I
 
 		this.startSimulator(options, device);
 		if (!options.skipInstall) {
-			this.simctl.install(device.id, applicationPath);
+			await this.installApplication(device.id, applicationPath);
 		}
 
 		return this.simctl.launch(device.id, applicationIdentifier, options);
@@ -73,8 +73,12 @@ export class XCodeSimctlSimulator extends IPhoneSimulatorNameGetter implements I
 		return common.getInstalledApplications(deviceId);
 	}
 
-	public installApplication(deviceId: string, applicationPath: string): Promise<void> {
-		return this.simctl.install(deviceId, applicationPath);
+	public async installApplication(deviceId: string, applicationPath: string): Promise<void> {
+		try {
+			await this.simctl.install(deviceId, applicationPath);
+		} catch (err) {
+			await this.simctl.install(deviceId, applicationPath);
+		}
 	}
 
 	public uninstallApplication(deviceId: string, appIdentifier: string):  Promise<void> {
@@ -196,7 +200,7 @@ export class XCodeSimctlSimulator extends IPhoneSimulatorNameGetter implements I
 		if (!device && options.device) {
 			await this.verifyDevice(options.device);
 		}
-		
+
 		device = device || await this.getDeviceToRun(options);
 
 		// In case the id is undefined, skip verification - we'll start default simulator.
@@ -258,9 +262,5 @@ export class XCodeSimctlSimulator extends IPhoneSimulatorNameGetter implements I
 		const availableDevices = await this.getDevices();
 
 		return _.find(availableDevices, { id: deviceId });
-	}
-
-	private killSimulator(): void {
-		childProcess.execSync("pkill -9 -f Simulator");
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-sim-portable",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "",
   "main": "./lib/ios-sim.js",
   "scripts": {


### PR DESCRIPTION
When using Xcode 10, the `xcrun simctl install ...` command fails every other time with error:
```
Error: Command xcrun with arguments simctl install 5516E083-C749-47A7-A6FC-2EE2E414D025 /Users/vladimirov/Work/nativescript-cli/scratch/app1/platforms/ios/build/emulator/app1.app failed with exit code 1. Error output:
 An error was encountered processing the command (domain=IXUserPresentableErrorDomain, code=1):
This app could not be installed at this time.
Failed to load Info.plist from bundle at path /Users/vladimirov/Library/Developer/CoreSimulator/Devices/5516E083-C749-47A7-A6FC-2EE2E414D025/data/Library/Caches/com.apple.mobile.installd.staging/temp.ZdmYQa/extracted/Payload/app1.app
Failed to load Info.plist from bundle at path /Users/vladimirov/Library/Developer/CoreSimulator/Devices/5516E083-C749-47A7-A6FC-2EE2E414D025/data/Library/Caches/com.apple.mobile.installd.staging/temp.ZdmYQa/extracted/Payload/app1.app
Underlying error (domain=MIInstallerErrorDomain, code=35):
	Failed to load Info.plist from bundle at path /Users/vladimirov/Library/Developer/CoreSimulator/Devices/5516E083-C749-47A7-A6FC-2EE2E414D025/data/Library/Caches/com.apple.mobile.installd.staging/temp.ZdmYQa/extracted/Payload/app1.app
```

It looks like during install of the application, the content of the built `.app` is extracted to a temp folder in some cases. While the installation is in progress, Xcode decides it is done and deletes the temp dir. However, the package is installed on device, but it is still loading some data from the package that is installed (the temp dir). It fails, as it searches for Info.plist file in the package we've installed, but it is not there. So the installation process fails and app remains on device with inconsitent state.
Retrying the operation fixes the behavior.