### PR TITLE
fix: log process is not started on getDeviceLogProcess

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-sim-portable",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "",
   "main": "./lib/ios-sim.js",
   "scripts": {


### PR DESCRIPTION
In some cases (especially with Xcode 10), calling getDeviceLogProcess returns a childProcess for the logs, that is not started yet.
This breaks `tns debug ios --start` in CLI as the logs are not sent to the CLI immediately and it fails to find the port for debugging.