### PR TITLE
fix: use correct spawn method in order to fix livesync

### DIFF
--- a/lib/iphone-simulator-xcode-simctl.ts
+++ b/lib/iphone-simulator-xcode-simctl.ts
@@ -170,7 +170,7 @@ export class XCodeSimctlSimulator extends IPhoneSimulatorNameGetter implements I
 					}
 				} else {
 					const logFilePath = path.join(osenv.home(), "Library", "Logs", "CoreSimulator", deviceId, "system.log");
-					this.deviceLogChildProcess = childProcess.spawn("tail", ['-f', '-n', '1', logFilePath]);
+					this.deviceLogChildProcess = child_process.spawn("tail", ['-f', '-n', '1', logFilePath]);
 					fulfillSafe();
 				}
 


### PR DESCRIPTION
`childProcess.spawn` is blocking method and waits for close event to resolve the promise. Actually we'll never received `close` event because we want to read log file all the time. So use `child_process.spawn` in order to fix livesync command.