### PR TITLE
fix: add timeout when stopping application

### DIFF
--- a/lib/iphone-simulator-xcode-simctl.ts
+++ b/lib/iphone-simulator-xcode-simctl.ts
@@ -105,6 +105,9 @@ export class XCodeSimctlSimulator extends IPhoneSimulatorNameGetter implements I
 			}
 		} catch (e) {
 		}
+
+		await this.simctl.terminate(deviceId, appIdentifier);
+		utils.sleep(0.5);
 	}
 
 	private getPid(deviceId: string, bundleExecutable: string): string {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-sim-portable",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "description": "",
   "main": "./lib/ios-sim.js",
   "scripts": {


### PR DESCRIPTION
On slower machines, `kill -9` says its stopped the application, but it is still runing on iOS Simulator. For this cases, trying to call `launch` after that leads to error or undefined behavior.
Try to fix this by calling `xcrun simctl terminate` after the kill and add half second timeout.