### PR TITLE
fix: popup is shown when searching for iOS Simulators

### DIFF
--- a/lib/child-process.ts
+++ b/lib/child-process.ts
@@ -1,8 +1,8 @@
 import * as child_process from "child_process";
 
-export function execSync(command: string, opts?: any): any {
+export function execSync(command: string, execSyncOptions?: child_process.ExecSyncOptions, opts?: ISkipErrorComposition): any {
 	try {
-		return child_process.execSync(command, opts);
+		return child_process.execSync(command, execSyncOptions);
 	} catch (err) {
 		if (opts && opts.skipError) {
 			return err;
@@ -12,9 +12,9 @@ export function execSync(command: string, opts?: any): any {
 	}
 }
 
-export function spawnSync(command: string, args: string[], opts?: any): any {
+export function spawnSync(command: string, args: string[], spawnSyncOpts?: child_process.SpawnSyncOptions, opts?: ISkipErrorComposition): any {
 	try {
-		return child_process.spawnSync(command, args, opts);
+		return child_process.spawnSync(command, args, spawnSyncOpts);
 	} catch (err) {
 		if (opts && opts.skipError) {
 			return err;
@@ -24,12 +24,12 @@ export function spawnSync(command: string, args: string[], opts?: any): any {
 	}
 }
 
-export function spawn(command: string, args: string[], opts?: any): Promise<string> {
+export function spawn(command: string, args: string[], spawnOpts?: child_process.SpawnOptions, opts?: ISkipErrorComposition): Promise<string> {
 	return new Promise<string>((resolve, reject) => {
 		let capturedOut = "";
 		let capturedErr = "";
 
-		let childProcess = child_process.spawn(command, args);
+		let childProcess = child_process.spawn(command, args, spawnOpts);
 
 		if (childProcess.stdout) {
 			childProcess.stdout.on("data", (data: string) => {

--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -26,12 +26,16 @@ interface IDevice {
 	rawDevice?: any; // NodObjC wrapper to device
 }
 
+interface ISkipErrorComposition {
+	skipError: boolean;
+}
+
 interface ISimctl {
 	launch(deviceId: string, applicationIdentifier: string, options: IOptions): Promise<string>;
 	boot(deviceId: string): Promise<void>;
 	terminate(deviceId: string, appIdentifier: string): Promise<string>;
 	install(deviceId: string, applicationPath: string): Promise<void>;
-	uninstall(deviceId: string, applicationIdentifier: string, opts?: any): Promise<void>;
+	uninstall(deviceId: string, applicationIdentifier: string, opts?: ISkipErrorComposition): Promise<void>;
 	notifyPost(deviceId: string, notification: string): Promise<void>;
 	getDevices(): Promise<IDevice[]>;
 	getLog(deviceId: string, predicate?: string): any;

--- a/lib/iphone-simulator-xcode-simctl.ts
+++ b/lib/iphone-simulator-xcode-simctl.ts
@@ -97,7 +97,7 @@ export class XCodeSimctlSimulator extends IPhoneSimulatorNameGetter implements I
 		try {
 			let pid = this.getPid(deviceId, bundleExecutable);
 			while (pid) {
-				childProcess.execSync(`kill -9 ${pid}`, { skipError: true });
+				childProcess.execSync(`kill -9 ${pid}`, null, { skipError: true });
 				pid = this.getPid(deviceId, bundleExecutable);
 				if (pid) {
 					utils.sleep(0.1);
@@ -117,7 +117,7 @@ export class XCodeSimctlSimulator extends IPhoneSimulatorNameGetter implements I
 		// The process, that is execed by Node.js is also returned, so we need to exclude it from the result.
 		// To achieve this, remove the command we've executed from the ps result.
 		const grepAppProcessCommand = `ps -ef | grep ${bundleExecutable} | grep \/${deviceId}\/`;
-		return childProcess.execSync(`${grepAppProcessCommand} | grep -v "${grepAppProcessCommand}" | awk '{print $2}'`, { skipError: true }).toString().trim();
+		return childProcess.execSync(`${grepAppProcessCommand} | grep -v "${grepAppProcessCommand}" | awk '{print $2}'`, null, { skipError: true }).toString().trim();
 }
 
 	public async getDeviceLogProcess(deviceId: string, predicate?: string): Promise<child_process.ChildProcess> {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-sim-portable",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "description": "",
   "main": "./lib/ios-sim.js",
   "scripts": {


### PR DESCRIPTION
When Xcode Command Line tools are not installed, calling `xcrun` leads to a popup with suggestion to install Xcode Command Line Tools. Prevent this by checking if Xcode is installed and if not - do not spawn `xcrun`.
Fix incorrect interfaces and remove unused method.