### PR TITLE
chore: update shelljs to last version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "bplist-parser": "0.3.2",
     "lodash": "4.17.21",
     "plist": "3.0.6",
-    "shelljs": "~0.8.4",
+    "shelljs": "~0.9.2",
     "yargs": "17.7.1"
   },
   "devDependencies": {


### PR DESCRIPTION
ShellJS uses glob@7.2.3, which is marked as deprecated. ShellJS no longer uses glob, so we won't see any deprecations when installing the CLI.
